### PR TITLE
Add import mode for bulk name entry

### DIFF
--- a/src/components/Controls.module.scss
+++ b/src/components/Controls.module.scss
@@ -19,11 +19,16 @@
       &:hover {
         filter: var(--icon-shift);
       }
+
+      &.active {
+        color: var(--accent-color);
+      }
     }
   }
 
   .nameInputForm {
     display: flex;
+    align-items: flex-start;
     margin-bottom: 1rem;
 
     .nameInput {
@@ -33,6 +38,8 @@
       border: 1px solid var(--border-color);
       background-color: var(--textarea-background-color);
       color: var(--text-color);
+      resize: none;
+      overflow: hidden;
 
       &::placeholder {
         color: var(--code-text-color);
@@ -49,7 +56,9 @@
       color: var(--icon-color);
       font-size: 1.5rem;
       cursor: pointer;
-      padding: 0 0.5rem;
+      padding: 0.5rem 0.5rem;
+      display: flex;
+      align-items: center;
 
       &:hover {
         filter: var(--icon-shift);

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import NameList from './NameList';
 import styles from './Controls.module.scss';
 import { shareUrl } from '../utils/url';
@@ -16,7 +16,16 @@ const Controls: React.FC<ControlsProps> = ({
   onToggleTheme,
 }) => {
   const [name, setName] = useState('');
+  const [isImportMode, setIsImportMode] = useState(false);
   const nextId = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isImportMode && textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [name, isImportMode]);
 
   const handleAddName = (name: string) => {
     const newPerson: Person = {
@@ -28,6 +37,17 @@ const Controls: React.FC<ControlsProps> = ({
     setPeople([...people, newPerson]);
   };
 
+  const handleImportNames = (rawNames: string) => {
+    const names = rawNames.split('\n').map(n => n.trim()).filter(n => n !== '');
+    nextId.current = 0;
+    const newPeople = names.map(name => ({
+      id: nextId.current++,
+      name,
+      enabled: true,
+    }));
+    setPeople(newPeople);
+  };
+
   const handleShare = () => {
     shareUrl(people.map(p => p.name));
   };
@@ -36,8 +56,21 @@ const Controls: React.FC<ControlsProps> = ({
     e.preventDefault();
 
     if (name.trim()) {
-      handleAddName(name.trim());
+      if (isImportMode) {
+        handleImportNames(name);
+        setIsImportMode(false);
+      } else {
+        handleAddName(name.trim());
+      }
       setName('');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (isImportMode && e.key === 'Enter') {
+      // In import mode, we want Enter to add a newline, not submit the form
+      // Textarea does this by default, but we'll stop propagation just in case
+      e.stopPropagation();
     }
   };
 
@@ -50,6 +83,13 @@ const Controls: React.FC<ControlsProps> = ({
           title="Share"
         >
           <span className="fa fa-share"></span>
+        </button>
+        <button
+          onClick={() => setIsImportMode(!isImportMode)}
+          className={`${styles.iconButton} ${isImportMode ? styles.active : ''}`}
+          title="Import names"
+        >
+          <span className="fa fa-file-import"></span>
         </button>
         <button
           onClick={onToggleTheme}
@@ -65,26 +105,40 @@ const Controls: React.FC<ControlsProps> = ({
         className={styles.nameInputForm}
         onSubmit={handleSubmit}
       >
-        <input
-          type="text"
-          className={styles.nameInput}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Enter a name"
-        />
+        {isImportMode ? (
+          <textarea
+            ref={textareaRef}
+            className={styles.nameInput}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Enter multiple names (one per line)"
+            rows={1}
+          />
+        ) : (
+          <input
+            type="text"
+            className={styles.nameInput}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Enter a name"
+          />
+        )}
         <button
           type="submit"
           className={styles.addButton}
-          aria-label="Add"
+          aria-label={isImportMode ? "Replace names" : "Add name"}
         >
-          <span className="fa fa-regular fa-square-plus"></span>
+          <span className={`fa fa-regular ${isImportMode ? 'fa-square-check' : 'fa-square-plus'}`}></span>
         </button>
       </form>
 
-      <NameList
-        people={people}
-        setPeople={setPeople}
-      />
+      {!isImportMode && (
+        <NameList
+          people={people}
+          setPeople={setPeople}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Implemented an import mode for the wheel of names. This feature allows users to bulk enter names in an auto-growing textarea, replacing the existing list of names upon submission. The NameList is hidden in this mode to provide more space for the textarea. Icons and styling were updated to match the application's theme and provide visual feedback for the active mode.

---
*PR created automatically by Jules for task [8958624136086614781](https://jules.google.com/task/8958624136086614781) started by @matthewdenaburg1*