### PR TITLE
Add bulk import names feature

### DIFF
--- a/src/components/Controls.module.scss
+++ b/src/components/Controls.module.scss
@@ -26,6 +26,10 @@
     display: flex;
     margin-bottom: 1rem;
 
+    &.importMode {
+      align-items: flex-start;
+    }
+
     .nameInput {
       flex-grow: 1;
       padding: 0.5rem;
@@ -33,6 +37,10 @@
       border: 1px solid var(--border-color);
       background-color: var(--textarea-background-color);
       color: var(--text-color);
+      resize: none;
+      max-height: 500px;
+      overflow-y: auto;
+      font-family: inherit;
 
       &::placeholder {
         color: var(--code-text-color);

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import NameList from './NameList';
 import styles from './Controls.module.scss';
 import { shareUrl } from '../utils/url';
@@ -16,7 +16,17 @@ const Controls: React.FC<ControlsProps> = ({
   onToggleTheme,
 }) => {
   const [name, setName] = useState('');
+  const [isImportMode, setIsImportMode] = useState(false);
+  const [importValue, setImportValue] = useState('');
   const nextId = useRef(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isImportMode && textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [importValue, isImportMode]);
 
   const handleAddName = (name: string) => {
     const newPerson: Person = {
@@ -35,9 +45,28 @@ const Controls: React.FC<ControlsProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (name.trim()) {
-      handleAddName(name.trim());
-      setName('');
+    if (isImportMode) {
+      const names = importValue
+        .split('\n')
+        .map((n) => n.trim())
+        .filter((n) => n.length > 0);
+
+      if (names.length > 0) {
+        nextId.current = 0;
+        const newPeople = names.map((name) => ({
+          id: nextId.current++,
+          name,
+          enabled: true,
+        }));
+        setPeople(newPeople);
+        setImportValue('');
+        setIsImportMode(false);
+      }
+    } else {
+      if (name.trim()) {
+        handleAddName(name.trim());
+        setName('');
+      }
     }
   };
 
@@ -58,20 +87,38 @@ const Controls: React.FC<ControlsProps> = ({
         >
           <span className="fa fa-lightbulb"></span>
         </button>
+        <button
+          onClick={() => setIsImportMode(!isImportMode)}
+          className={styles.iconButton}
+          title="Import"
+        >
+          <span className="fa fa-file-import"></span>
+        </button>
       </div>
 
       {/* name input form */}
       <form
-        className={styles.nameInputForm}
+        className={`${styles.nameInputForm} ${isImportMode ? styles.importMode : ''}`}
         onSubmit={handleSubmit}
       >
-        <input
-          type="text"
-          className={styles.nameInput}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Enter a name"
-        />
+        {isImportMode ? (
+          <textarea
+            ref={textareaRef}
+            className={styles.nameInput}
+            value={importValue}
+            onChange={(e) => setImportValue(e.target.value)}
+            placeholder="Enter names, one per line"
+            rows={1}
+          />
+        ) : (
+          <input
+            type="text"
+            className={styles.nameInput}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Enter a name"
+          />
+        )}
         <button
           type="submit"
           className={styles.addButton}
@@ -81,10 +128,12 @@ const Controls: React.FC<ControlsProps> = ({
         </button>
       </form>
 
-      <NameList
-        people={people}
-        setPeople={setPeople}
-      />
+      {!isImportMode && (
+        <NameList
+          people={people}
+          setPeople={setPeople}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This change introduces a bulk import feature to the Wheel of Names application. Users can now click an import icon in the controls menu to switch to a multi-line input mode. In this mode, the name list is hidden, and the input field becomes a larger, auto-growing textarea where multiple names can be entered (one per line). Upon clicking the "Add" button, the current list of names is replaced with the newly entered ones. The textarea is styled to match the app's theme and is constrained to a maximum height with a scrollbar to maintain UI consistency.

---
*PR created automatically by Jules for task [14299470166268415594](https://jules.google.com/task/14299470166268415594) started by @matthewdenaburg1*